### PR TITLE
refactor: use whiskers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,13 @@
 <img src="assets/mocha.webp"/>
 </details>
 
-## About
-
-This port offers the colors needed for ST's header files, but **not an ST build**.
-
 ## Usage
 
-1. Choose your flavour.
-2. Copy the contents of `flavour.h` and replace into your st build's `config.h`.
-3. Then `make install` it in st folder.
+> [!NOTE]
+> This port offers the colors needed for ST's header files, but **not an ST build**.
+
+1. Copy the contents of the flavor of your choice from [`themes/`](./themes/) into your st build's `config.h`.
+2. Then `make install` it in the st folder.
 
 ## 💝 Thanks to
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers st.tera

--- a/st.tera
+++ b/st.tera
@@ -1,0 +1,43 @@
+---
+whiskers:
+  version: "2.3.0"
+  matrix:
+    - flavor
+  filename: "themes/{{ flavor.identifier }}.h"
+---
+/* Terminal colors (16 first used in escape sequence) */
+static const char *colorname[] = {
+	/* 8 normal colors */
+	"#{{ if(cond=flavor.dark, t=surface1.hex, f=subtext1.hex) }}",
+	"#{{ red.hex }}",
+	"#{{ green.hex }}",
+	"#{{ yellow.hex }}",
+	"#{{ blue.hex }}",
+	"#{{ pink.hex }}",
+	"#{{ teal.hex }}",
+	"#{{ if(cond=flavor.dark, t=subtext1.hex, f=surface2.hex) }}",
+
+	/* 8 bright colors */
+	"#{{ if(cond=flavor.dark, t=surface2.hex, f=subtext0.hex) }}",
+	"#{{ red.hex }}",
+	"#{{ green.hex }}",
+	"#{{ yellow.hex }}",
+	"#{{ blue.hex }}",
+	"#{{ pink.hex }}",
+	"#{{ teal.hex }}",
+	"#{{ if(cond=flavor.dark, t=subtext0.hex, f=surface1.hex) }}",
+
+[256] = "#{{ text.hex }}", /* default foreground colour */
+[257] = "#{{ base.hex }}", /* default background colour */
+[258] = "#{{ rosewater.hex }}", /*575268*/
+
+};
+
+
+/*
+ * foreground, background, cursor, reverse cursor
+ */
+unsigned int defaultfg = 256;
+unsigned int defaultbg = 257;
+unsigned int defaultcs = 258;
+static unsigned int defaultrcs = 258;

--- a/st.tera
+++ b/st.tera
@@ -4,6 +4,7 @@ whiskers:
   matrix:
     - flavor
   filename: "themes/{{ flavor.identifier }}.h"
+  capitalize_hex: true
 ---
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {

--- a/themes/frappe.h
+++ b/themes/frappe.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#5C5F77",
-	"#D20F39",
-	"#40A02B",
-	"#DF8E1D",
-	"#1E66F5",
-	"#EA76CB",
-	"#179299",
-	"#ACB0BE",
+	"#51576d",
+	"#e78284",
+	"#a6d189",
+	"#e5c890",
+	"#8caaee",
+	"#f4b8e4",
+	"#81c8be",
+	"#b5bfe2",
 
 	/* 8 bright colors */
-	"#6C6F85",
-	"#D20F39",
-	"#40A02B",
-	"#DF8E1D",
-	"#1E66F5",
-	"#EA76CB",
-	"#179299",
-	"#BCC0CC",
+	"#626880",
+	"#e78284",
+	"#a6d189",
+	"#e5c890",
+	"#8caaee",
+	"#f4b8e4",
+	"#81c8be",
+	"#a5adce",
 
-[256] = "#4C4F69", /* default foreground colour */
-[257] = "#EFF1F5", /* default background colour */
-[258] = "#DC8A78", /*575268*/
+[256] = "#c6d0f5", /* default foreground colour */
+[257] = "#303446", /* default background colour */
+[258] = "#f2d5cf", /*575268*/
 
 };
 

--- a/themes/frappe.h
+++ b/themes/frappe.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#51576d",
-	"#e78284",
-	"#a6d189",
-	"#e5c890",
-	"#8caaee",
-	"#f4b8e4",
-	"#81c8be",
-	"#b5bfe2",
+	"#51576D",
+	"#E78284",
+	"#A6D189",
+	"#E5C890",
+	"#8CAAEE",
+	"#F4B8E4",
+	"#81C8BE",
+	"#B5BFE2",
 
 	/* 8 bright colors */
 	"#626880",
-	"#e78284",
-	"#a6d189",
-	"#e5c890",
-	"#8caaee",
-	"#f4b8e4",
-	"#81c8be",
-	"#a5adce",
+	"#E78284",
+	"#A6D189",
+	"#E5C890",
+	"#8CAAEE",
+	"#F4B8E4",
+	"#81C8BE",
+	"#A5ADCE",
 
-[256] = "#c6d0f5", /* default foreground colour */
+[256] = "#C6D0F5", /* default foreground colour */
 [257] = "#303446", /* default background colour */
-[258] = "#f2d5cf", /*575268*/
+[258] = "#F2D5CF", /*575268*/
 
 };
 

--- a/themes/latte.h
+++ b/themes/latte.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#5c5f77",
-	"#d20f39",
-	"#40a02b",
-	"#df8e1d",
-	"#1e66f5",
-	"#ea76cb",
+	"#5C5F77",
+	"#D20F39",
+	"#40A02B",
+	"#DF8E1D",
+	"#1E66F5",
+	"#EA76CB",
 	"#179299",
-	"#acb0be",
+	"#ACB0BE",
 
 	/* 8 bright colors */
-	"#6c6f85",
-	"#d20f39",
-	"#40a02b",
-	"#df8e1d",
-	"#1e66f5",
-	"#ea76cb",
+	"#6C6F85",
+	"#D20F39",
+	"#40A02B",
+	"#DF8E1D",
+	"#1E66F5",
+	"#EA76CB",
 	"#179299",
-	"#bcc0cc",
+	"#BCC0CC",
 
-[256] = "#4c4f69", /* default foreground colour */
-[257] = "#eff1f5", /* default background colour */
-[258] = "#dc8a78", /*575268*/
+[256] = "#4C4F69", /* default foreground colour */
+[257] = "#EFF1F5", /* default background colour */
+[258] = "#DC8A78", /*575268*/
 
 };
 

--- a/themes/latte.h
+++ b/themes/latte.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#494D64",
-	"#ED8796",
-	"#A6DA95",
-	"#EED49F",
-	"#8AADF4",
-	"#F5BDE6",
-	"#8BD5CA",
-	"#B8C0E0",
+	"#5c5f77",
+	"#d20f39",
+	"#40a02b",
+	"#df8e1d",
+	"#1e66f5",
+	"#ea76cb",
+	"#179299",
+	"#acb0be",
 
 	/* 8 bright colors */
-	"#5B6078",
-	"#ED8796",
-	"#A6DA95",
-	"#EED49F",
-	"#8AADF4",
-	"#F5BDE6",
-	"#8BD5CA",
-	"#A5ADCB",
+	"#6c6f85",
+	"#d20f39",
+	"#40a02b",
+	"#df8e1d",
+	"#1e66f5",
+	"#ea76cb",
+	"#179299",
+	"#bcc0cc",
 
-[256] = "#CAD3F5", /* default foreground colour */
-[257] = "#24273A", /* default background colour */
-[258] = "#F4DBD6", /*575268*/
+[256] = "#4c4f69", /* default foreground colour */
+[257] = "#eff1f5", /* default background colour */
+[258] = "#dc8a78", /*575268*/
 
 };
 

--- a/themes/macchiato.h
+++ b/themes/macchiato.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#494d64",
-	"#ed8796",
-	"#a6da95",
-	"#eed49f",
-	"#8aadf4",
-	"#f5bde6",
-	"#8bd5ca",
-	"#b8c0e0",
+	"#494D64",
+	"#ED8796",
+	"#A6DA95",
+	"#EED49F",
+	"#8AADF4",
+	"#F5BDE6",
+	"#8BD5CA",
+	"#B8C0E0",
 
 	/* 8 bright colors */
-	"#5b6078",
-	"#ed8796",
-	"#a6da95",
-	"#eed49f",
-	"#8aadf4",
-	"#f5bde6",
-	"#8bd5ca",
-	"#a5adcb",
+	"#5B6078",
+	"#ED8796",
+	"#A6DA95",
+	"#EED49F",
+	"#8AADF4",
+	"#F5BDE6",
+	"#8BD5CA",
+	"#A5ADCB",
 
-[256] = "#cad3f5", /* default foreground colour */
-[257] = "#24273a", /* default background colour */
-[258] = "#f4dbd6", /*575268*/
+[256] = "#CAD3F5", /* default foreground colour */
+[257] = "#24273A", /* default background colour */
+[258] = "#F4DBD6", /*575268*/
 
 };
 

--- a/themes/macchiato.h
+++ b/themes/macchiato.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#51576D",
-	"#E78284",
-	"#A6D189",
-	"#E5C890",
-	"#8CAAEE",
-	"#F4B8E4",
-	"#81C8BE",
-	"#B5BFE2",
+	"#494d64",
+	"#ed8796",
+	"#a6da95",
+	"#eed49f",
+	"#8aadf4",
+	"#f5bde6",
+	"#8bd5ca",
+	"#b8c0e0",
 
 	/* 8 bright colors */
-	"#626880",
-	"#E78284",
-	"#A6D189",
-	"#E5C890",
-	"#8CAAEE",
-	"#F4B8E4",
-	"#81C8BE",
-	"#A5ADCE",
+	"#5b6078",
+	"#ed8796",
+	"#a6da95",
+	"#eed49f",
+	"#8aadf4",
+	"#f5bde6",
+	"#8bd5ca",
+	"#a5adcb",
 
-[256] = "#C6D0F5", /* default foreground colour */
-[257] = "#303446", /* default background colour */
-[258] = "#F2D5CF", /*575268*/
+[256] = "#cad3f5", /* default foreground colour */
+[257] = "#24273a", /* default background colour */
+[258] = "#f4dbd6", /*575268*/
 
 };
 

--- a/themes/mocha.h
+++ b/themes/mocha.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#45475A",
-	"#F38BA8",
-	"#A6E3A1",
-	"#F9E2AF",
-	"#89B4FA",
-	"#F5C2E7",
-	"#94E2D5",
-	"#BAC2DE",
+	"#45475a",
+	"#f38ba8",
+	"#a6e3a1",
+	"#f9e2af",
+	"#89b4fa",
+	"#f5c2e7",
+	"#94e2d5",
+	"#bac2de",
 
 	/* 8 bright colors */
-	"#585B70",
-	"#F38BA8",
-	"#A6E3A1",
-	"#F9E2AF",
-	"#89B4FA",
-	"#F5C2E7",
-	"#94E2D5",
-	"#A6ADC8",
+	"#585b70",
+	"#f38ba8",
+	"#a6e3a1",
+	"#f9e2af",
+	"#89b4fa",
+	"#f5c2e7",
+	"#94e2d5",
+	"#a6adc8",
 
-[256] = "#CDD6F4", /* default foreground colour */
-[257] = "#1E1E2E", /* default background colour */
-[258] = "#F5E0DC", /*575268*/
+[256] = "#cdd6f4", /* default foreground colour */
+[257] = "#1e1e2e", /* default background colour */
+[258] = "#f5e0dc", /*575268*/
 
 };
 

--- a/themes/mocha.h
+++ b/themes/mocha.h
@@ -1,28 +1,28 @@
 /* Terminal colors (16 first used in escape sequence) */
 static const char *colorname[] = {
 	/* 8 normal colors */
-	"#45475a",
-	"#f38ba8",
-	"#a6e3a1",
-	"#f9e2af",
-	"#89b4fa",
-	"#f5c2e7",
-	"#94e2d5",
-	"#bac2de",
+	"#45475A",
+	"#F38BA8",
+	"#A6E3A1",
+	"#F9E2AF",
+	"#89B4FA",
+	"#F5C2E7",
+	"#94E2D5",
+	"#BAC2DE",
 
 	/* 8 bright colors */
-	"#585b70",
-	"#f38ba8",
-	"#a6e3a1",
-	"#f9e2af",
-	"#89b4fa",
-	"#f5c2e7",
-	"#94e2d5",
-	"#a6adc8",
+	"#585B70",
+	"#F38BA8",
+	"#A6E3A1",
+	"#F9E2AF",
+	"#89B4FA",
+	"#F5C2E7",
+	"#94E2D5",
+	"#A6ADC8",
 
-[256] = "#cdd6f4", /* default foreground colour */
-[257] = "#1e1e2e", /* default background colour */
-[258] = "#f5e0dc", /*575268*/
+[256] = "#CDD6F4", /* default foreground colour */
+[257] = "#1E1E2E", /* default background colour */
+[258] = "#F5E0DC", /*575268*/
 
 };
 


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's in-house templating tool, to build the themes. Instead of editing the `.h` files directly, edit the `st.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.